### PR TITLE
added babel-runtime as dependency in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "processenv",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "processenv parses environment variables.",
   "contributors": [
     {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     }
   ],
   "main": "dist/processEnv.js",
-  "dependencies": {},
+  "dependencies": {
+    "babel-runtime": "6.26.0"
+  },
   "devDependencies": {
     "assertthat": "1.0.0",
     "nodeenv": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "processenv",
-  "version": "1.0.2",
+  "version": "1.0.1",
   "description": "processenv parses environment variables.",
   "contributors": [
     {
@@ -10,6 +10,10 @@
     {
       "name": "Matthias Wagler",
       "email": "matthias.wagler@thenativeweb.io"
+    },
+    {
+      "name": "Peter Winter",
+      "email": "peter@pwntr.com"
     }
   ],
   "main": "dist/processEnv.js",


### PR DESCRIPTION
Hi Golo. Since the babel-runtime was missing locally for me, I wasn't able to successfully use the module after your recent update to 1.0.1 today. Installing said runtime locally solved the issue, unsurprisingly. Hence, I added it as a dependency in package.json and increased the version number to 1.0.2. Someone else might stumble on this sooner or later.