### PR TITLE
Fixed boolean handling by adding a new parameter to set a default value

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,14 @@ Then, to parse an environment variable, call the `processenv` function and provi
 const port = processenv('PORT');
 ```
 
-If the environment variable is not set, `processenv` returns `undefined`. Hence, if you want to provide a default value, use the usual JavaScript `||` operator.
+If you want to provide a default value, you can add it as a second parameter. This also works for booleans and all other types. If neither the environment variable nor the desired default value are set, `processenv` returns `undefined`.
+
+```javascript
+const port = processenv('PORT', 3000);
+const dryrun = processenv('DRYRUN', true);
+```
+
+The usual JavaScript `||` operator works as well for providing default values, just not for all constellations of booleans. For instance, reading a boolean environment variable that is set to `false`, with a desired default if unset of `true`, still yields `true` in all cases. If you use booleans, use the above syntax with a second parameter instead.
 
 ```javascript
 const port = processenv('PORT') || 3000;

--- a/dist/processEnv.js
+++ b/dist/processEnv.js
@@ -14,7 +14,7 @@ var normalize = function normalize(value) {
   }
 };
 
-var processEnv = function processEnv(key) {
+var processEnv = function processEnv(key, alt = undefined) {
   if (!key) {
     var environmentVariables = {};
 
@@ -31,7 +31,10 @@ var processEnv = function processEnv(key) {
   var value = process.env[key];
   /* eslint-enable no-process-env */
 
-  if (!value) {
+  if (value === undefined && alt !== undefined) {
+    return alt;
+  }
+  if (value === undefined && alt === undefined) {
     return undefined;
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "processenv",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "processenv parses environment variables.",
   "contributors": [
     {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     }
   ],
   "main": "dist/processEnv.js",
-  "dependencies": {},
+  "dependencies": {
+    "babel-runtime": "6.26.0"
+  },
   "devDependencies": {
     "assertthat": "1.0.0",
     "nodeenv": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "processenv",
-  "version": "1.0.2",
+  "version": "1.0.1",
   "description": "processenv parses environment variables.",
   "contributors": [
     {
@@ -10,6 +10,10 @@
     {
       "name": "Matthias Wagler",
       "email": "matthias.wagler@thenativeweb.io"
+    },
+    {
+      "name": "Peter Winter",
+      "email": "peter@pwntr.com"
     }
   ],
   "main": "dist/processEnv.js",

--- a/src/processEnv.js
+++ b/src/processEnv.js
@@ -8,7 +8,7 @@ const normalize = function (value) {
   }
 };
 
-const processEnv = function (key) {
+const processEnv = function (key, alt = undefined) {
   if (!key) {
     const environmentVariables = {};
 
@@ -25,7 +25,10 @@ const processEnv = function (key) {
   const value = process.env[key];
   /* eslint-enable no-process-env */
 
-  if (!value) {
+  if (value === undefined && alt !== undefined) {
+    return alt;
+  }
+  if (value === undefined && alt === undefined) {
     return undefined;
   }
 


### PR DESCRIPTION
Moin @goloroden.

First :grin:!

- Fixed  #2. Added a new parameter (`alt`), and `processEnv` now explicitly checks `value` for being `undefined` rather than `false` _or_ `undefined`, making the behavior deterministic and enabling proper boolean default handling when setting the the default value via the second parameter.
- Updated the `readme.md` accordingly.
- Doesn't break previous behavior (except for instances in which someone relied on the bug).

I'd propose lifting the version to 1.1.0 since a new parameter / function signature was introduced.

Cheers,
Peter